### PR TITLE
Fix bug: add configuraiton "fromname: this.emailConfig.name," into te…

### DIFF
--- a/lib/Sendcloud.js
+++ b/lib/Sendcloud.js
@@ -173,6 +173,7 @@ var SendCloud = (function () {
         api_user: this.emailConfig.apiUser,
         api_key: this.emailConfig.apiKey,
         from: this.emailConfig.from,
+        fromname: this.emailConfig.name,
         template_invoke_name: templateName,
         subject: subject,
         substitution_vars: JSON.stringify({

--- a/src/Sendcloud.js
+++ b/src/Sendcloud.js
@@ -138,6 +138,7 @@ class SendCloud {
       api_user: this.emailConfig.apiUser,
       api_key: this.emailConfig.apiKey,
       from: this.emailConfig.from,
+      fromname: this.emailConfig.name,
       template_invoke_name: templateName,
       subject: subject,
       substitution_vars: JSON.stringify({


### PR DESCRIPTION
Fix bug: add configuraiton "fromname: this.emailConfig.name," into templateToOne function.

When I use this function, the received email cannot correctly display sender's name, thus I found this small bug. 
You can see the difference.
**Before**:
![image](https://cloud.githubusercontent.com/assets/26496557/24228267/1b7568c4-0fae-11e7-9b15-c017b7930e79.png)
**After**:
![image](https://cloud.githubusercontent.com/assets/26496557/24228272/21f70112-0fae-11e7-86c2-789b310c82b1.png)
